### PR TITLE
Fix link to getting started page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Getting Started
 
-<a href="https://strapi.io/getting-started)" target="_blank">Read the Getting Started tutorial</a> or follow the steps below:
+<a href="https://strapi.io/getting-started" target="_blank">Read the Getting Started tutorial</a> or follow the steps below:
 
 #### ⏳ Installation
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix: The getting started link in the README had a closing parenthesis in the end, causing it to 404.
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
Documentation
<!-- Framework -->
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
